### PR TITLE
return single " if cid not found

### DIFF
--- a/src/main/java/mimeparser/MimeMessageConverter.java
+++ b/src/main/java/mimeparser/MimeMessageConverter.java
@@ -190,9 +190,10 @@ public class MimeMessageConverter {
                     public String replace(Matcher m) throws Exception {
                         MimeObjectEntry<String> base64Entry = inlineImageMap.get("<" + m.group(1) + ">");
 
-                        // found no image for this cid, just return the matches string as it is
+                        // found no image for this cid, just return single " to avoid problem with wkhtmltopdf
                         if (base64Entry == null) {
-                            return m.group();
+                            Logger.warn("CID not found: " + m.group(1));
+                            return "\"";
                         }
 
                         return "data:" + base64Entry.getContentType().getBaseType() + ";base64," + base64Entry.getEntry() + "\"";


### PR DESCRIPTION
returning the original cid string results in wkhtmltopdf failing: Protocol "cid" is unknown.

(this problem happened in the wild with a mail where two cid attachments were missing)

One could also return a placeholder 1x1 image, but my fix also works in production 😆