### PR TITLE
allow wkhtmltopdf DPI to be specified via CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Usage: EmailToPDFConverter [options] <email-file>
     -s, --page-size
       Set wkhtmltopdf paper size to: A4, Letter, etc. (default A4)
       Default: A4
+    -r, --dpi
+      Set wkhtmltopdf DPI. (default 300)
+      Default: 300
     -p, --proxy
       Proxy (e.g. "http://10.64.1.74:81"). If "auto" is supplied the default
       system proxy will be used.

--- a/src/main/java/cli/CommandLineParameters.java
+++ b/src/main/java/cli/CommandLineParameters.java
@@ -65,6 +65,9 @@ public class CommandLineParameters {
     @Parameter(names = {"-s", "--page-size"}, description = "Set wkhtmltopdf paper size to: A4, Letter, etc. (default A4)")
     private String pageSize = "A4";
 
+    @Parameter(names = {"-r", "--dpi"}, description = "Set wkhtmltopdf DPI. (default 300)")
+    private String dpi = "300";
+
     public List<String> getFiles() {
         return files;
     }
@@ -167,5 +170,13 @@ public class CommandLineParameters {
 
     public void setPageSize(String pageSize) {
         this.pageSize = pageSize;
+    }
+
+    public String getDPI() {
+        return dpi;
+    }
+
+    public void setDPI(String dpi) {
+        this.dpi = dpi;
     }
 }

--- a/src/main/java/cli/Main.java
+++ b/src/main/java/cli/Main.java
@@ -119,6 +119,9 @@ public class Main {
         extParams.add("--page-size");
         extParams.add(cli.getPageSize());
 
+        extParams.add("--dpi");
+        extParams.add(cli.getDPI());
+
         try {
             MimeMessageConverter.convertToPdf(in, out, cli.isHideHeaders(), cli.isExtractAttachments(), cli.getExtractAttachmentsDir(), extParams);
         } catch (Exception e) {

--- a/src/main/java/mimeparser/MimeMessageConverter.java
+++ b/src/main/java/mimeparser/MimeMessageConverter.java
@@ -86,7 +86,6 @@ public class MimeMessageConverter {
     private static final Pattern IMG_CID_PLAIN_REGEX = Pattern.compile("\\[cid:(.*?)\\]", Pattern.DOTALL);
 
     private static final String VIEWPORT_SIZE = "2480x3508";
-    private static final int CONVERSION_DPI = 300;
     private static final int IMAGE_QUALITY = 100;
 
     private static final DateFormat DATE_FORMATTER = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG);
@@ -299,7 +298,6 @@ public class MimeMessageConverter {
                 "--viewport-size", VIEWPORT_SIZE,
                 "--enable-local-file-access",
                 // "--disable-smart-shrinking",
-                "--dpi", String.valueOf(CONVERSION_DPI),
                 "--image-quality", String.valueOf(IMAGE_QUALITY),
                 "--encoding", charsetName));
         cmd.addAll(extParams);


### PR DESCRIPTION
First of all, thank you for this very useful project. It allows me to convert my emails to PDFs easily!

For some emails the font size of the resulting PDF files was very small (as compared to a normal PDF viewer). Decreasing the DPI value (from 300 to 150) fixed this issue for me. To make the DPI value customizable at runtime, this PR introduces the `--dpi` CLI argument to allow the user to override the default 300DPI. The short option `-r` is supposed to be short for "resolution".