### PR TITLE
try to decode partially invalidly encoded subject lines with heuristic

### DIFF
--- a/src/test/java/mimeparser/MimeMessageConverterTest.java
+++ b/src/test/java/mimeparser/MimeMessageConverterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Nick Russler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mimeparser;
+
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static mimeparser.MimeMessageConverter.heuristicallyDecodeInvalidHeaderEncoding;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MimeMessageConverterTest {
+    @Test
+    public void heuristicallyDecodeInvalidHeaderEncoding_alreadyCorrectlyDecodedSubject() throws UnsupportedEncodingException {
+        final String expected = "Sörën ißt àáçäßæåëýðèçýìèþùéèöùœĳ«";
+        final String actual = heuristicallyDecodeInvalidHeaderEncoding(expected);
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void heuristicallyDecodeInvalidHeaderEncoding_heuristicWorksWithSpaces() throws UnsupportedEncodingException {
+        final String input = "=?ISO-8859-1?Q?Bananen sch=E4lt man mit einem Messer?=";
+        final String expected = "Bananen schält man mit einem Messer";
+        final String actual = heuristicallyDecodeInvalidHeaderEncoding(input);
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void heuristicallyDecodeInvalidHeaderEncoding_weirdButValidHeader() throws UnsupportedEncodingException {
+        final String expected = "=? foobar";
+        final String actual = heuristicallyDecodeInvalidHeaderEncoding(expected);
+        assertThat(actual, equalTo(expected));
+    }
+}


### PR DESCRIPTION
While converting some emails, I noticed that some subject lines contained MIME encoding prefixes in the decoded subject, although my email client displayed them correctly. (e.g. `"=?ISO-8859-1?Q?Bananen sch=E4lt man mit einem Messer?="` instead of `Bananen schält man mit einem Messer`)

It seems like many emails are sent with email headers with invalid encoding, but most email clients try to decode the subject line anyways.

This [stackoverflow answer](https://stackoverflow.com/a/4725175) describes the issues of spaces being not allowed in a encoded subject line.

This PR implements a heuristic which checks if the subject line potentially is still encoded (i.e. starts with "=?"), then replaces the spaces with placeholders, tries a decoding, replaces the placeholders with spaces again.

IMHO this project should stick as close as possible to how a mail client would render an email. Therefore I suggest not to hide this heuristic behind a CLI flag.