### PR TITLE
Feature/cc and attachment names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage: EmailToPDFConverter [options] <email-file>
       Default: false
     -aa, --add-attachment-names
       Add the list of attachment names under the body text
-      Default: false	  
+      Default: false
     -a, --extract-attachments
       Extract Attachments.
       Default: false

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Usage: EmailToPDFConverter [options] <email-file>
     -e, --error
       Display only Error messages.
       Default: false
+	-aa, --add-attachment-names
+      Add the list of attachment names under the body text
+      Default: false	  
     -a, --extract-attachments
       Extract Attachments.
       Default: false

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Usage: EmailToPDFConverter [options] <email-file>
   Options:
     -d, --debug
       Debug mode
-      Display only Error messages.
       Default: false
     -e, --error
+      Display only Error messages.
       Default: false
     -aa, --add-attachment-names
       Add the list of attachment names under the body text

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Usage: EmailToPDFConverter [options] <email-file>
   Options:
     -d, --debug
       Debug mode
-      Default: false
-    -e, --error
       Display only Error messages.
       Default: false
-	-aa, --add-attachment-names
+    -e, --error
+      Default: false
+    -aa, --add-attachment-names
       Add the list of attachment names under the body text
       Default: false	  
     -a, --extract-attachments

--- a/src/main/java/gui/MainWindow.java
+++ b/src/main/java/gui/MainWindow.java
@@ -245,15 +245,15 @@ public class MainWindow {
         chckbxUseProxy.setBounds(10, 43, 86, 23);
         panel.add(chckbxUseProxy);
 
-        final JCheckBox chckbxAddAttachmentNames = new JCheckBox("Add Attachment Names");
-        chckbxAddAttachmentNames.setBackground(Color.WHITE);
-        chckbxAddAttachmentNames.setBounds(10, 69, 180, 23);
-        panel.add(chckbxAddAttachmentNames);
-
         final JCheckBox chckbxExtractAttachments = new JCheckBox("Extract Attachments");
         chckbxExtractAttachments.setBackground(Color.WHITE);
-        chckbxExtractAttachments.setBounds(10, 69, 180, 23);
+        chckbxExtractAttachments.setBounds(10, 69, 150, 23);
         panel.add(chckbxExtractAttachments);
+
+        final JCheckBox chckbxAddAttachmentNames = new JCheckBox("Add Attachment Names");
+        chckbxAddAttachmentNames.setBackground(Color.WHITE);
+        chckbxAddAttachmentNames.setBounds(160, 69, 180, 23);
+        panel.add(chckbxAddAttachmentNames);
 
         JPanel panelProgress = new JPanel();
         panelProgress.setBorder(new TitledBorder(null, "", TitledBorder.LEADING, TitledBorder.TOP, null, null));

--- a/src/test/resources/eml/testPlainWithCC.eml
+++ b/src/test/resources/eml/testPlainWithCC.eml
@@ -1,31 +1,11 @@
-Message-ID: <4f47f54c-c86a-463f-8841-fa8f93fd1c56@withcc.com>
-Date: Tue, 2 Jan 2024 08:56:47 +0100
-MIME-Version: 1.0
-User-Agent: Mozilla Thunderbird
-Content-Language: it
-To: account1@testwithcc.com
-Cc: account2@testwithcc.com
-From: TestWithCC <test@withcc.com>
-Subject: this is a test!
-X-Mozilla-Draft-Info: internal/draft; vcard=0; receipt=1; DSN=0; uuencode=0;
- attachmentreminder=0; deliveryformat=0
-X-Identity-Key: id2
-Fcc: imap://m.barrese%40golemsoftware.com@imaps.aruba.it/INBOX/Sent
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: 7bit
+Mime-Version: 1.0
+Date: Thu, 11 Dec 2014 05:20:45 -0800
+Message-ID: <31959B35C53.000000FBy.aaaat@ibbx.com>
+From: =?UTF-8?Q?bolo_y=C3=BCkselulupe?= <y.aaaat@ibbx.com>
+Subject: FW: RE: yeni projeler
+To: naaa.rddder@aaal.com
+Cc: naaa2.rddder2@aaal.com
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-<!DOCTYPE html>
-<html>
-  <head>
-
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-  </head>
-  <body>
-    <p>Hello world!<br>
-    </p>
-    <div class="moz-signature"><a><br>
-        <br>
-        <br>
-      </a></div>
-  </body>
-</html>
+Hallo, Guten Tag!


### PR DESCRIPTION
correct overlap of two checkboxes in gui
added "-aa, --add-attachment-names" command line option in README.md